### PR TITLE
Fixing issue where docker install did not reflect updated iptables

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -212,17 +212,15 @@ class Swarm:
           cwd=self.config.build_dir,
           env=temp_env).wait()
     subprocess.Popen(
+        ['ansible-playbook', 'security-lockdown.yml'],
+        cwd=self.config.build_dir,
+        env=temp_env).wait()
+    subprocess.Popen(
         ['ansible-playbook', 'install-docker.yml'],
         cwd=self.config.build_dir,
         env=temp_env).wait()
     subprocess.Popen(
         ['ansible-playbook', 'add-sudo-users.yml'],
-        cwd=self.config.build_dir,
-        env=temp_env).wait()
-
-    temp_env['ANSIBLE_CONFIG'] = 'appdev.cfg'
-    subprocess.Popen(
-        ['ansible-playbook', 'security-lockdown.yml'],
         cwd=self.config.build_dir,
         env=temp_env).wait()
 


### PR DESCRIPTION
If `docker` was installed before the `iptables` script ran, there was an issue where the cache for `iptables` had to be cleared & the `docker` daemon had to be restarted.

This fixes that issue, and I tested by deploying Uplift on this branch.