### PR TITLE
Remove copying TLS certificate to server

### DIFF
--- a/playbooks/configure-stack.yml
+++ b/playbooks/configure-stack.yml
@@ -8,15 +8,3 @@
         src: docker-compose
         dest: /home/appdev/
         owner: appdev
-
-- hosts: all
-  become: yes
-  tasks:
-    - name: ensure tls certificate directory exists
-      file:
-        path: /etc/docker/certs.d/104.236.60.90:443
-        state: directory
-    - name: copy over registry tls certificate
-      copy:
-        src: domain.crt
-        dest: /etc/docker/certs.d/104.236.60.90:443/ca.crt


### PR DESCRIPTION
We're going to host images on `Docker Hub` instead, so we don't need to copy a TLS certificate over anymore in future deployments.