### PR TITLE
Fix error in Config

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -32,6 +32,8 @@ class Config:
     self.compose_dir = os.path.join(self.bundle_dir, 'docker-compose')
     if (bundle_path != None):
       self.hosts_file = os.path.join(self.bundle_dir, 'hosts')
+    else:
+      self.hosts_file = None
 
     self.public_key_file = os.path.join(self.bundle_dir, 'server.pem.pub')
     self.private_key_file = os.path.join(self.bundle_dir, 'server.pem')


### PR DESCRIPTION
<img width="585" alt="screen shot 2018-11-13 at 11 24 31 pm" src="https://user-images.githubusercontent.com/22579863/48462504-6e8b2400-e7a6-11e8-858b-8bd74ae12960.png">

When I ran `python manage.py config`, I would get this error since `self.hosts_file` could have never been assigned.